### PR TITLE
Fix typo and exclude node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 /composer.phar
 /.idea
 /.vagrant
-node_modules
+/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /composer.phar
 /.idea
 /.vagrant
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+Some ground rules
+
+1. Keep all commits, comments, descriptions, etc. in English
+2. Fork the Repo and send a pull request
+3. Always add a description in your pull request
+4. Use the labels (`Work In Progress`, `Ready For Review`, `Ready For Merge`, `Needs Work`)
+5. Make sure you wright according unit tests to your code
+6. We stick with [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) as much as possible
+
+Once your PR has been reviewed and approved it will be merged and deployed to production.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Some ground rules
 2. Fork the Repo and send a pull request
 3. Always add a description in your pull request
 4. Use the labels (`Work In Progress`, `Ready For Review`, `Ready For Merge`, `Needs Work`)
-5. Make sure you wright according unit tests to your code
+5. Make sure you write according unit tests to your code
 6. We stick with [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) as much as possible
 
 Once your PR has been reviewed and approved it will be merged and deployed to production.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Welcome in the CoderDojo Nederland Website repository. The website is completely
 
 # What to do?
 
-We keep track of stuff to do in the [Gitgub Issue](https://github.com/CoderDojoNederland/website/issues) list. Here you can mainly see 2 different categories; Bugs & Ideas. Both can either be reported or accepted. The accepted ones are ready to be picked up, the reported ones are ready to be discussed and then accepted / rejected.
+We keep track of stuff to do in the [GitHub Issue](https://github.com/CoderDojoNederland/website/issues) list. Here you can mainly see 2 different categories; Bugs & Ideas. Both can either be reported or accepted. The accepted ones are ready to be picked up, the reported ones are ready to be discussed and then accepted / rejected.
 
 # How to Contribute
 


### PR DESCRIPTION
Noticed a small typo in the readme file.

Next to that I noticed that after following the instructions, node_modules was not ignored. Added this folder to the gitignore file.