### PR TITLE
Choose recipient for contact form

### DIFF
--- a/src/Coderdojo/WebsiteBundle/Controller/DefaultController.php
+++ b/src/Coderdojo/WebsiteBundle/Controller/DefaultController.php
@@ -34,7 +34,9 @@ class DefaultController extends Controller
      */
     public function contactAction(Request $request)
     {
-        $form = $this->createForm(new ContactFormType());
+        $dojos = $this->getDoctrine()->getRepository('CoderdojoWebsiteBundle:Dojo')->findBy([],['city'=>'asc']);
+
+        $form = $this->createForm(new ContactFormType($dojos));
 
         if ($request->isMethod('POST')) {
             $form->submit($request);
@@ -42,8 +44,9 @@ class DefaultController extends Controller
             if ($form->isValid()) {
                 $message = \Swift_Message::newInstance()
                     ->setSubject($form->get('subject')->getData())
-                    ->setFrom($form->get('email')->getData(), $form->get('naam')->getData())
-                    ->setTo('contact@coderdojo.nl')
+                    ->setFrom('no-reply@coderdojo.nl', $form->get('naam')->getData())
+                    ->setReplyTo($form->get('email')->getData())
+                    ->setTo($form->get('ontvanger')->getData())
                     ->setContentType('text/html')
                     ->setBody(
                         $this->renderView(

--- a/src/Coderdojo/WebsiteBundle/Form/Type/ContactFormType.php
+++ b/src/Coderdojo/WebsiteBundle/Form/Type/ContactFormType.php
@@ -2,8 +2,10 @@
 
 namespace Coderdojo\WebsiteBundle\Form\Type;
 
+use Coderdojo\WebsiteBundle\Entity\Dojo;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
@@ -16,6 +18,16 @@ use Symfony\Component\Validator\Constraints\Collection;
  */
 class ContactFormType extends AbstractType
 {
+    /**
+     * @var Dojo[]
+     */
+    private $dojos;
+
+    public function __construct($dojos)
+    {
+        $this->dojos = $dojos;
+    }
+
     /**
      * Build the form
      *
@@ -31,6 +43,21 @@ class ContactFormType extends AbstractType
                 )
             ))
             ->add('email', 'email')
+            ->add('ontvanger', 'choice', [
+                'empty_value' => '- Kies een dojo -',
+                'mapped' => false,
+                'choices' => $this->buildChoices(),
+                'group_by' => function($val, $key, $index) {
+                    if ('contact@coderdojo.nl' !== $val) {
+                        return 'Lokale Dojo\'s';
+                    } else {
+                        return 'Algemene zaken';
+                    }
+                },
+                'attr' => [
+                    'class' => 'form-control'
+                ]
+            ])
             ->add('subject', 'text', array(
                 'label' => 'Onderwerp'
             ))
@@ -41,6 +68,20 @@ class ContactFormType extends AbstractType
                     'rows' => 10
                 )
             ));
+    }
+
+    protected function buildChoices()
+    {
+        $choices = [];
+
+        $choices['contact@coderdojo.nl'] = 'CoderDojo Nederland';
+
+        /** @var Dojo $dojo */
+        foreach ($this->dojos as $dojo) {
+            $choices[ $dojo->getEmail() ] = $dojo->getName();
+        }
+
+        return $choices;
     }
 
     /**

--- a/src/Coderdojo/WebsiteBundle/Resources/views/Form/fields.html.twig
+++ b/src/Coderdojo/WebsiteBundle/Resources/views/Form/fields.html.twig
@@ -56,23 +56,25 @@
 {%- endblock choice_widget_expanded -%}
 
 {%- block choice_widget_collapsed -%}
-    {%- if required and empty_value is none and not empty_value_in_choices and not multiple -%}
-        {% set required = false %}
-    {%- endif -%}
-    <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
-        {%- if empty_value is not none -%}
-            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
+    <div class="col-lg-10">
+        {%- if required and empty_value is none and not empty_value_in_choices and not multiple -%}
+            {% set required = false %}
         {%- endif -%}
-        {%- if preferred_choices|length > 0 -%}
-            {% set options = preferred_choices %}
-            {{- block('choice_widget_options') -}}
-            {%- if choices|length > 0 and separator is not none -%}
-                <option disabled="disabled">{{ separator }}</option>
+        <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
+            {%- if empty_value is not none -%}
+                <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
             {%- endif -%}
-        {%- endif -%}
-        {%- set options = choices -%}
-        {{- block('choice_widget_options') -}}
-    </select>
+            {%- if preferred_choices|length > 0 -%}
+                {% set options = preferred_choices %}
+                {{- block('choice_widget_options') -}}
+                {%- if choices|length > 0 and separator is not none -%}
+                    <option disabled="disabled">{{ separator }}</option>
+                {%- endif -%}
+            {%- endif -%}
+            {%- set options = choices -%}
+            {{- block('choice_widget_options') -}}
+        </select>
+    </div>
 {%- endblock choice_widget_collapsed -%}
 
 {%- block choice_widget_options -%}


### PR DESCRIPTION
When someone uses the contact form, it is now possible to choose a specific dojo to send the message to.

Hopefully this will help in directing local dojo messages to the right place!

![screenshot 2016-03-28 13 55 19](https://cloud.githubusercontent.com/assets/1062751/14077997/2e62cdc8-f4f2-11e5-9614-564c75bfb9f6.png)
