### PR TITLE
⚡️ Improved the dojos page

### DIFF
--- a/src/CoderDojo/WebsiteBundle/Entity/Dojo.php
+++ b/src/CoderDojo/WebsiteBundle/Entity/Dojo.php
@@ -269,7 +269,7 @@ class Dojo
     }
 
     /**
-     * @return DojoEvent[]
+     * @return DojoEvent[]|ArrayCollection
      */
     public function getEvents()
     {

--- a/src/CoderDojo/WebsiteBundle/Repository/DojoRepository.php
+++ b/src/CoderDojo/WebsiteBundle/Repository/DojoRepository.php
@@ -11,7 +11,7 @@ class DojoRepository extends EntityRepository
     /**
      * Fetch all dojos ordered by city
      *
-     * @return User[]
+     * @return Dojo[]
      */
     public function getSortedByCity()
     {

--- a/src/CoderDojo/WebsiteBundle/Resources/config/services.yml
+++ b/src/CoderDojo/WebsiteBundle/Resources/config/services.yml
@@ -29,6 +29,12 @@ services:
         tags:
             - { name: twig.extension }
 
+    coder_dojo.twig_extension.dojo:
+        class: CoderDojo\WebsiteBundle\Twig\DojoExtension
+        public: false
+        tags:
+            - { name: twig.extension }
+
     coder_dojo.website_bundle.slack_service:
         class: CoderDojo\WebsiteBundle\Service\SlackService
         arguments: ["%slack_api_token%", "@kernel"]

--- a/src/CoderDojo/WebsiteBundle/Resources/public/css/pages/page_dojos.css
+++ b/src/CoderDojo/WebsiteBundle/Resources/public/css/pages/page_dojos.css
@@ -42,6 +42,11 @@
   transition: background-color, 300ms;
   border-bottom: 1px solid #ededed;
 }
+
+.dojo-row p {
+  margin:0;
+}
+
 .dojo-row:hover {
   background-color: #ededed;
 }
@@ -50,9 +55,19 @@
   margin-bottom: 5px;
 }
 
+[data-js-ref=list-upcoming-dojos],
 [data-js-ref=list-all-dojos] {
   max-height: 500px;
   overflow-y: scroll;
+}
+
+@media (max-width: 450px) {
+  [data-js-ref=list-upcoming-dojos],
+  [data-js-ref=list-all-dojos] {
+    height: auto;
+    max-height: none;
+    overflow-y: auto;
+  }
 }
 
 /* emptystate for no upcoming dojos */

--- a/src/CoderDojo/WebsiteBundle/Resources/public/js/pages/dojos.js
+++ b/src/CoderDojo/WebsiteBundle/Resources/public/js/pages/dojos.js
@@ -116,8 +116,13 @@
 
   DojosMapBackground.prototype.showInfoWindowForDojoId = function (dojoId) {
     var dojo = this.dojos[dojoId],
-      windowContent = "<strong>" + dojo.name + "</strong><br>" +
-        dojo.city + "<br>";
+      windowContent = "<h5>" + dojo.name + "</h5>" +
+        "<p>" + dojo.city + "</p>";
+
+    if(dojo.nextUrl) {
+        windowContent += '<p><strong>Volgende dojo</strong>: ' + dojo.nextDate + '</p>' +
+            '<p><a href="'+dojo.nextUrl+'" class="btn-u btn-u-green btn-u-small">Registreren</a></p>';
+    }
 
     // close and nullify info window if already existing
     if (this.infoWindow) {

--- a/src/CoderDojo/WebsiteBundle/Resources/views/Pages/dojos.html.twig
+++ b/src/CoderDojo/WebsiteBundle/Resources/views/Pages/dojos.html.twig
@@ -19,12 +19,18 @@
   <script>
     window.dojos = {};
     {% for dojo in dojos %}
+    {%  set next = dojo|nextEvent %}
+
       dojos[{{dojo.id}}] = {
         id:           {{dojo.id}},
         name:         "{{dojo.name}}",
         city:         "{{dojo.city}}",
         twitter:      "{{dojo.twitter}}",
         website:      "{{dojo.website}}",
+          {% if next %}
+          nextUrl:        "{{ next.url }}",
+          nextDate:       "{{ next.date|date('d/m/Y') }}",
+          {% endif %}
         geo: {
           lat: {{dojo.lat}},
           long: {{dojo.lon}}
@@ -37,17 +43,16 @@
 {% endblock customjs %}
 
 {% block content %}
-
 <div class="content-wrapper">
 
-  <div id="all-dojos-map" class="map">
+  <div id="all-dojos-map" class="map hidden-xs">
   </div>
 
   <div class="container">
 
 
     <div class="row margin-bottom-30 dojo-selector">
-        <div class="col-md-6">
+        <div class="col-md-5 col-xs-12">
             <!--Orange Panels-->
             <div class="panel panel-orange">
 
@@ -60,43 +65,22 @@
 
                 <div class="panel-body" id="dojoeventlist" data-js-ref="list-upcoming-dojos">
 
-                  <!-- header row -->
-                  <div class="row dojos-header">
-                    <div class="col-xs-12">
-                      <div class="row">
-                        <div class="col-xs-4">
-                          <b>Locatie</b>
-                        </div>
-                        <div class="col-xs-4">
-                          <b>Datum</b>
-                        </div>
-                        <div class="col-xs-4">
-                          <b>Tickets</b>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
                   <!-- various dojo rows -->
                   {% if nextdojos|length > 0 %}
                       {% for event in nextdojos %}
                       <div class="row dojo-row" data-dojo-id="{{event.dojo.id}}">
-                        <div class="col-xs-12">
-                          <div class="row">
-                            <div class="col-xs-4">
-                              {{event.dojo.name|replace({'CoderDojo ':''})}}
-                            </div>
-                            <div class="col-xs-4">
-                              {{ event.date|localizeddate('none', 'none', 'nl_NL', null, "d MMMM Y")}}
-                            </div>
-                            <div class="col-xs-4">
-                              {% if event.type == 'zen' %}
-                                <a href="{{ event.dojo.zenUrl }}" target="_blank" class="btn-u btn-u-small btn-u-green" data-dojo-date="{{ event.date|date('Y/m/d') }}" data-dojo="{{ event.dojo.name }}">Reserveer</a>
-                              {% else %}
-                                <a href="{{ event.url }}" target="_blank" class="btn-u btn-u-small btn-u-green" data-dojo-date="{{ event.date|date('Y/m/d') }}" data-dojo="{{ event.dojo.name }}">Reserveer</a>
-                              {% endif %}
-                            </div>
-                          </div>
+                        <div class="col-xs-5">
+                          <strong>{{event.dojo.city|capitalize}}</strong>
+                        </div>
+                        <div class="col-xs-5">
+                          {{ event.date|localizeddate('none', 'none', 'nl_NL', null, "d MMMM Y")}}
+                        </div>
+                        <div class="col-xs-2" style="">
+                          {% if event.type == 'zen' %}
+                            <a href="{{ event.dojo.zenUrl }}" target="_blank" class="btn-u btn-u-small btn-u-green" data-dojo-date="{{ event.date|date('Y/m/d') }}" data-dojo="{{ event.dojo.name }}"><span class="glyphicon glyphicon-arrow-right"></span></a>
+                          {% else %}
+                            <a href="{{ event.url }}" target="_blank" class="btn-u btn-u-small btn-u-green" data-dojo-date="{{ event.date|date('Y/m/d') }}" data-dojo="{{ event.dojo.name }}"><span class="glyphicon glyphicon-arrow-right"></span></a>
+                          {% endif %}
                         </div>
                       </div>
                       {% endfor %}
@@ -115,41 +99,22 @@
                 </div>
 
                 <div class="panel-body hidden" id="dojolist" data-js-ref="list-all-dojos">
-                  <!-- header row -->
-                  <div class="row dojos-header">
-                    <div class="col-md-12">
-                      <div class="row">
-                        <div class="col-xs-7">
-                          <b>Naam</b>
-                        </div>
-                        <div class="col-xs-5">
-                          <b>Contact</b>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
                   <!-- various dojo rows -->
                   {% for dojo in dojos %}
                   <div class="row dojo-row" data-dojo-id="{{dojo.id}}">
-                    <div class="col-xs-12">
-                      <div class="row">
                         <!-- general dojo information -->
-                        <div class="col-xs-7">
-                          {{dojo.name}}
+                        <div class="col-xs-8" style="white-space: nowrap;overflow: hidden;">
+                          <p>{{dojo.name}}</p>
                         </div>
 
                         <!-- dojos contact buttons -->
-                        <div class="col-xs-5">
-                          <p class="contact-info">
+                        <div class="col-xs-4">
+                          <p class="contact-info" style="text-align: right;">
                             <a href="mailto:{{ dojo.email }}" title="Email"><i class="icon-envelope"></i></a>&nbsp;
                             <a href="{{ dojo.website }}" title="Website"><i class="icon-globe"></i></a>&nbsp;
                             <a href="http://twitter.com/{{ dojo.twitter }}" title="Twitter"><i class="icon-twitter"></i></a>&nbsp
                           </p>
                         </div>
-
-                      </div>
-                    </div>
                   </div>
                   {% endfor %}
 

--- a/src/CoderDojo/WebsiteBundle/Twig/DojoExtension.php
+++ b/src/CoderDojo/WebsiteBundle/Twig/DojoExtension.php
@@ -47,6 +47,6 @@ class DojoExtension extends \Twig_Extension
 
     public function getName()
     {
-        return 'random_extension';
+        return 'dojo_extension';
     }
 }

--- a/src/CoderDojo/WebsiteBundle/Twig/DojoExtension.php
+++ b/src/CoderDojo/WebsiteBundle/Twig/DojoExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace CoderDojo\WebsiteBundle\Twig;
+
+use CoderDojo\WebsiteBundle\Entity\Dojo;
+use CoderDojo\WebsiteBundle\Entity\DojoEvent;
+
+class DojoExtension extends \Twig_Extension
+{
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('nextEvent', array($this, 'nextEventFilter'))
+        );
+    }
+
+    /**
+     * @param Dojo $dojo
+     * @return DojoEvent|null
+     */
+    public function nextEventFilter(Dojo $dojo)
+    {
+        $events = $dojo->getEvents();
+
+        if ($events->isEmpty()) {
+            return null;
+        }
+
+        $events = array_filter($events->toArray(), function(DojoEvent $event){
+            if ($event->getDate() >= new \DateTime()) {
+                return true;
+            }
+
+            return false;
+        });
+
+        if (count($events) === 0) {
+            return null;
+        }
+
+        usort($events, function(DojoEvent $a, DojoEvent $b){
+            return $a->getDate() > $b->getDate();
+        });
+
+        return $events[0];
+    }
+
+    public function getName()
+    {
+        return 'random_extension';
+    }
+}


### PR DESCRIPTION
## What does it do?

It improves the dojo overview page. It was a bit messy and not suitable for smaller screens.

## How does it look?

<img width="1119" alt="screenshot 2017-01-26 19 55 14" src="https://cloud.githubusercontent.com/assets/1062751/22345779/ca6ec06a-e401-11e6-93b2-7f3df835c1c5.png">

<img width="1141" alt="screenshot 2017-01-26 19 55 22" src="https://cloud.githubusercontent.com/assets/1062751/22345783/ccfd1660-e401-11e6-8211-49869d79ed12.png">

<img width="286" alt="screenshot 2017-01-26 19 55 28" src="https://cloud.githubusercontent.com/assets/1062751/22345787/d07ee2fa-e401-11e6-85c2-287190607ad4.png">

## Migrations

:ok_hand: No migrations here.

## What has been done?

- [x] Made the overlay container less wide
- [x] Minor styling changes (Bold text etc.)
- [x] Smaller registration button
- [x] Added upcoming dojo to maps infowindow