### PR TITLE
Zen Synchronisation and Slack Notification

### DIFF
--- a/src/CoderDojo/CliBundle/Service/SyncDojoService.php
+++ b/src/CoderDojo/CliBundle/Service/SyncDojoService.php
@@ -330,7 +330,7 @@ class SyncDojoService
             $attachments[] = $attachment;
         }
 
-        $this->slackService->sendToChannel('#general', $message, $attachments);
+        $this->slackService->sendToChannel('#website-nl', $message, $attachments);
 
         foreach($this->unmatched as $unmatched) {
             $attachment = new Attachment();

--- a/src/CoderDojo/CliBundle/Service/SyncEventService.php
+++ b/src/CoderDojo/CliBundle/Service/SyncEventService.php
@@ -205,7 +205,7 @@ class SyncEventService
             return;
         }
 
-        $this->slackService->sendToChannel('#general', $message, $attachments);
+        $this->slackService->sendToChannel('#website-nl', $message, $attachments);
     }
 
     /**

--- a/src/CoderDojo/WebsiteBundle/Resources/config/services.yml
+++ b/src/CoderDojo/WebsiteBundle/Resources/config/services.yml
@@ -41,6 +41,12 @@ services:
         tags:
             - { name: twig.extension }
 
+    coder_dojo.website_bundle.repository.dojo:
+        class: Doctrine\ORM\EntityRepository
+        factory: ["@doctrine.orm.entity_manager", getRepository]
+        arguments:
+            - CoderDojo\WebsiteBundle\Entity\Dojo
+
     coder_dojo.website_bundle.slack_service:
         class: CoderDojo\WebsiteBundle\Service\SlackService
         arguments: ["%slack_api_token%", "@kernel"]
@@ -98,6 +104,14 @@ services:
         arguments: ["@coder_dojo.website_bundle.slack_service"]
         tags:
             - { name: event_subscriber, subscribes_to: "CoderDojo\\WebsiteBundle\\Event\\DojoCreatedEvent"}
+
+    coder_dojo.website_bundle.subscriber.event_created_event.notify_slack:
+        class: CoderDojo\WebsiteBundle\Subscriber\EventCreatedEvent\NotifySlack
+        arguments:
+          - "@coder_dojo.website_bundle.slack_service"
+          - "@coder_dojo.website_bundle.repository.dojo"
+        tags:
+            - { name: event_subscriber, subscribes_to: "CoderDojo\\WebsiteBundle\\Event\\EventCreatedEvent"}
 
     coder_dojo.website_bundle.subscriber.coc_request_created_event.notify_champion:
         class: CoderDojo\WebsiteBundle\Subscriber\CocRequestCreatedEvent\NotifyChampion

--- a/src/CoderDojo/WebsiteBundle/Subscriber/EventCreatedEvent/NotifySlack.php
+++ b/src/CoderDojo/WebsiteBundle/Subscriber/EventCreatedEvent/NotifySlack.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace CoderDojo\WebsiteBundle\Subscriber\EventCreatedEvent;
+
+use CL\Slack\Model\Attachment;
+use CL\Slack\Model\AttachmentField;
+use CoderDojo\WebsiteBundle\Entity\Dojo;
+use CoderDojo\WebsiteBundle\Event\DojoCreatedEvent;
+use CoderDojo\WebsiteBundle\Event\EventCreatedEvent;
+use CoderDojo\WebsiteBundle\Repository\DojoRepository;
+use CoderDojo\WebsiteBundle\Service\SlackService;
+
+class NotifySlack
+{
+    /**
+     * @var SlackService
+     **/
+    private $slackService;
+
+    /**
+     * @var DojoRepository
+     */
+    private $dojoRepository;
+
+    /**
+     * NotifySlack constructor.
+     * @param SlackService   $slackService
+     * @param DojoRepository $dojoRepository
+     */
+    public function __construct(
+        SlackService $slackService,
+        DojoRepository $dojoRepository
+    ) {
+        $this->slackService = $slackService;
+        $this->dojoRepository = $dojoRepository;
+    }
+
+    public function notify(EventCreatedEvent $event)
+    {
+        /** @var Dojo $dojo */
+        $dojo = $this->dojoRepository->find($event->getDojoId());
+
+        $dateFormatter = new \IntlDateFormatter(
+            'nl_NL',
+            \IntlDateFormatter::FULL,
+            \IntlDateFormatter::FULL,
+            'Europe/Amsterdam',
+            \IntlDateFormatter::GREGORIAN,
+            'dd MMMM Y'
+        );
+
+        $attachment = new Attachment();
+        $attachment->setFallback(
+            sprintf(
+                'Er is een nieuw event toegevoegd in %s op %s! Inschrijven: %s',
+                $dojo->getCity(),
+                $dateFormatter->format($event->getDate()),
+                $event->getUrl()
+            )
+        );
+        $attachment->setText('Er is een nieuw event toegevoegd!');
+        $attachment->setColor('good');
+
+        $nameField = new AttachmentField();
+        $nameField->setTitle('Naam');
+        $nameField->setValue($event->getName());
+        $nameField->setShort(true);
+
+        $cityField = new AttachmentField();
+        $cityField->setTitle('Locatie');
+        $cityField->setValue($dojo->getCity());
+        $cityField->setShort(true);
+
+        $registerLinkField = new AttachmentField();
+        $registerLinkField->setTitle('Inschrijven via:');
+        $registerLinkField->setValue($event->getUrl());
+        $registerLinkField->setShort(true);
+
+        $dateField = new AttachmentField();
+        $dateField->setTitle('Datum');
+        $dateField->setValue($dateFormatter->format($event->getDate()));
+        $dateField->setShort(true);
+
+        $attachment->addField($nameField);
+        $attachment->addField($cityField);
+        $attachment->addField($registerLinkField);
+        $attachment->addField($dateField);
+
+        $this->slackService->sendToChannel('#general', '', [$attachment]);
+    }
+}


### PR DESCRIPTION
From now on the notifications in #general will be sent to #website-nl and only newly added dojo's or events will appear in #general. This should help releave the general channel of unnecessary noise.