### PR TITLE
Split city on comma instead of space

### DIFF
--- a/src/CoderDojo/CliBundle/Service/ZenApiService.php
+++ b/src/CoderDojo/CliBundle/Service/ZenApiService.php
@@ -48,7 +48,7 @@ class ZenApiService
                 $city = $externalDojo->place;
             }
 
-            $city = explode(" ", $city);
+            $city = explode(",", $city);
             $city = array_pop($city);
 
             $removed = false;


### PR DESCRIPTION
Some cities have spaces in their names, so this method was bogus...